### PR TITLE
Decrease dependencies versions.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Config::Processor.
 
+0.11 Wen Nov 23 12:30:00 MSK 2016
+  - Decrease dependencies versions.
+  - Cosmetic changes
+
 0.10 Tue Jun 21 11:00:00 MSK 2016
   - Now module will always try to search configuration files in current
     directory.

--- a/Changes
+++ b/Changes
@@ -1,9 +1,5 @@
 Revision history for Perl extension Config::Processor.
 
-0.11 Wen Nov 23 12:30:00 MSK 2016
-  - Decrease dependencies versions.
-  - Cosmetic changes
-
 0.10 Tue Jun 21 11:00:00 MSK 2016
   - Now module will always try to search configuration files in current
     directory.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,8 +6,8 @@ WriteMakefile(
   VERSION_FROM       => 'lib/Config/Processor.pm',
   PREREQ_PM          => {
     'File::Spec'       => '0',
-    'YAML::XS'         => '0.62',
-    'Cpanel::JSON::XS' => '3.0213',
+    'YAML::XS'         => '0.41',
+    'Cpanel::JSON::XS' => '3.0104',
     'Hash::Merge'      => '0.200',
     'Scalar::Util'     => '0',
     'Carp'             => '0',


### PR DESCRIPTION
There is no need to install latest modules versions from CPAN. It simplifies using module on debian 8.